### PR TITLE
Add support for Symfony Client

### DIFF
--- a/symfony.plugin.zsh
+++ b/symfony.plugin.zsh
@@ -1,18 +1,28 @@
 # Basic command completion
 
-_symfony_console_script() {
+_symfony_console() {
+    if [[ -x "$dir/symfony" ]]; then
+        # local Symfony Client
+        echo "$dir/symfony" console"
+        return 0;
+    elif command -v symfony >/dev/null 2>&1; then
+        # Symfony Client in PATH
+        echo "$(command -v symfony) console"
+        return 0;
+    fi
+
     dir="$PWD";
 
     # Upward search
     while ((1)); do
 
         if [[ -f "$dir/bin/console" ]]; then
-            # Symfony 3
-            echo "$dir/bin/console";
+            # Symfony 3 + 4
+            echo "php $dir/bin/console";
             return 0;
         elif [[ -f "$dir/app/console" ]]; then
             # Symfony 2
-            echo "$dir/app/console";
+            echo "php $dir/app/console";
             return 0;
         fi
 
@@ -22,10 +32,6 @@ _symfony_console_script() {
     done
 
     return 1;
-}
-
-_symfony_console () {
-  echo "php `_symfony_console_script`"
 }
 
 _symfony_xdebug_console () {


### PR DESCRIPTION
Symfony has a new [Symfony Client](https://github.com/symfony/cli), which is a binary called `symfony`.
You can use `symfony console` the same way as the old way with `php bin/console` with an incredible difference: It loads a local `php.ini`. [docs](https://symfony.com/doc/current/setup/symfony_server.html#overriding-php-config-options-per-project)

I don't know anything about compdef and never contributed to a zsh plugin. So this is just a typed idea.

I think there could be something like this, but it doesn't work as expected:
```bash
compdef _symfony2 'symfony console'
```
Could you please implement this?

Upstream: https://github.com/robbyrussell/oh-my-zsh/pull/7888